### PR TITLE
Change the font used by checkboxes to match UWP

### DIFF
--- a/src/Uno.Playground.WASM/WasmCSS/Fonts.css
+++ b/src/Uno.Playground.WASM/WasmCSS/Fonts.css
@@ -27,3 +27,7 @@ body::after {
     pointer-events: none;
     position: absolute;
 }
+
+.uno-checkbox .uno-panel > .uno-textblock {
+    font-family: 'Segoe MDL2 Assets' !important;
+}


### PR DESCRIPTION
GitHub Issue (If applicable): #22 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

- Bugfix 
- Style fix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Checkboxes in Uno.Playground use the WinJS Symbols font, leading to the wrong styling.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
The checkmark uses Segoe MDL2 Assets instead.  
I'm pretty sure this is an absolutely horrible way to fix this, and that changing the default font used in Uno.UI for the Checkbox control would be better.  

...Thing is, I couldn't figure out how to fix it there 😅, or if that's wanted. (MDL2 being closed source and all.)  Guidance would be most welcome!

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
