### PR TITLE
chore: bump playground to latest uno

### DIFF
--- a/src/Uno.Playground.WASM/Uno.Playground.WASM.csproj
+++ b/src/Uno.Playground.WASM/Uno.Playground.WASM.csproj
@@ -102,14 +102,14 @@
 		<PackageReference Include="Uno.Toolkit.WinUI" Version="6.4.1" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="6.4.1" />
 
-		<PackageReference Include="Uno.WinUI.WebAssembly" Version="5.6.30" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="5.6.30" />
+		<PackageReference Include="Uno.WinUI.WebAssembly" Version="6.5.64" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="6.5.64" />
 		<PackageReference Include="Uno.Core.Extensions" Version="4.1.1" />
 		<PackageReference Include="Uno.Core.Extensions.Compatibility" Version="4.1.1" />
 		<PackageReference Include="Uno.Core" Version="4.1.1" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="5.6.30" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.WinUI.MediaPlayer.WebAssembly" Version="5.6.30" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="5.6.30" />
+		<PackageReference Include="Uno.WinUI.DevServer" Version="6.5.64" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.WinUI.MediaPlayer.WebAssembly" Version="6.5.64" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="6.5.64" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="9.0.10" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="9.0.10" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno.samples-private/issues/147

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Update uno package versions to 6.5
