### PR TITLE
fix(ci): add Linux host disk cleanup for CI builds

### DIFF
--- a/.github/actions/host-cleanup-linux/action.yml
+++ b/.github/actions/host-cleanup-linux/action.yml
@@ -1,0 +1,33 @@
+# Reclaim disk space on Linux CI hosts to prevent "no space left on device" failures.
+# Usage (composite action — call from any workflow job):
+#   - uses: ./.github/actions/host-cleanup-linux
+#
+# The step condition restricts execution to Linux runners only.
+
+name: 'Host Cleanup (Linux)'
+description: 'Free disk space on Ubuntu runners by removing unused toolchains'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Reclaim disk space (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "=== Disk usage BEFORE cleanup ==="
+        df -h /
+
+        # ── Remove large optional toolchains ──
+        sudo rm -rf ~/.cargo ~/.rustup ~/.dotnet /usr/share/swift \
+                     /opt/microsoft/msedge /usr/local/.ghcup /usr/lib/mono \
+                     /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+
+        # ── Snap packages (each is 200-500 MB) ──
+        sudo snap remove --purge lxd       2>/dev/null || true
+        sudo snap remove --purge core20    2>/dev/null || true
+        sudo snap remove --purge snapd     2>/dev/null || true
+        sudo apt-get purge -y snapd       2>/dev/null || true
+
+        echo "=== Disk usage AFTER cleanup ==="
+        df -h /

--- a/.github/actions/host-cleanup-linux/action.yml
+++ b/.github/actions/host-cleanup-linux/action.yml
@@ -1,33 +1,10 @@
-# Reclaim disk space on Linux CI hosts to prevent "no space left on device" failures.
-# Usage (composite action — call from any workflow job):
-#   - uses: ./.github/actions/host-cleanup-linux
-#
-# The step condition restricts execution to Linux runners only.
-
-name: 'Host Cleanup (Linux)'
-description: 'Free disk space on Ubuntu runners by removing unused toolchains'
+name: Host Cleanup (Linux)
+description: Reclaims disk space on Linux CI agents by removing unused pre-installed software
 
 runs:
   using: 'composite'
   steps:
-    - name: Reclaim disk space (Linux)
+    - name: Cleanup unused host dependencies
       if: runner.os == 'Linux'
       shell: bash
-      run: |
-        set -euo pipefail
-        echo "=== Disk usage BEFORE cleanup ==="
-        df -h /
-
-        # ── Remove large optional toolchains ──
-        sudo rm -rf ~/.cargo ~/.rustup ~/.dotnet /usr/share/swift \
-                     /opt/microsoft/msedge /usr/local/.ghcup /usr/lib/mono \
-                     /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-
-        # ── Snap packages (each is 200-500 MB) ──
-        sudo snap remove --purge lxd       2>/dev/null || true
-        sudo snap remove --purge core20    2>/dev/null || true
-        sudo snap remove --purge snapd     2>/dev/null || true
-        sudo apt-get purge -y snapd       2>/dev/null || true
-
-        echo "=== Disk usage AFTER cleanup ==="
-        df -h /
+      run: bash "$GITHUB_WORKSPACE/build/scripts/host-cleanup-linux.sh"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
           fetch-depth: 0 # Required for gitversion
           submodules: true
 
+      - uses: ./.github/actions/host-cleanup-linux
+
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v3.1.11
         with:

--- a/.vsts-ci.Linux.yml
+++ b/.vsts-ci.Linux.yml
@@ -10,6 +10,8 @@ jobs:
   - checkout: self
     clean: true
 
+  - template: build/host-cleanup-linux.yml
+
   - task: UseDotNet@2
     displayName: 'Use .NET SDK'
     retryCountOnTaskFailure: 3

--- a/build/host-cleanup-linux.yml
+++ b/build/host-cleanup-linux.yml
@@ -1,0 +1,27 @@
+# Reclaim disk space on Linux CI hosts to prevent "no space left on device" failures.
+# Usage (Azure DevOps step template):
+#   - template: build/host-cleanup-linux.yml
+#
+# This template is safe on all agents — the condition restricts it to Linux only.
+
+steps:
+  - bash: |
+      set -euo pipefail
+      echo "=== Disk usage BEFORE cleanup ==="
+      df -h /
+
+      # ── Remove large optional toolchains ──
+      sudo rm -rf ~/.cargo ~/.rustup ~/.dotnet /usr/share/swift \
+                   /opt/microsoft/msedge /usr/local/.ghcup /usr/lib/mono \
+                   /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+
+      # ── Snap packages (each is 200-500 MB) ──
+      sudo snap remove --purge lxd       2>/dev/null || true
+      sudo snap remove --purge core20    2>/dev/null || true
+      sudo snap remove --purge snapd     2>/dev/null || true
+      sudo apt-get purge -y snapd       2>/dev/null || true
+
+      echo "=== Disk usage AFTER cleanup ==="
+      df -h /
+    displayName: 'Reclaim disk space (Linux)'
+    condition: eq(variables['Agent.OS'], 'Linux')

--- a/build/host-cleanup-linux.yml
+++ b/build/host-cleanup-linux.yml
@@ -1,27 +1,7 @@
-# Reclaim disk space on Linux CI hosts to prevent "no space left on device" failures.
-# Usage (Azure DevOps step template):
-#   - template: build/host-cleanup-linux.yml
-#
-# This template is safe on all agents — the condition restricts it to Linux only.
-
+# Reusable AzDO template: Cleanup unused dependencies on Linux CI agents.
+# Calls the shared host-cleanup-linux.sh script to avoid duplication with GitHub Actions.
 steps:
   - bash: |
-      set -euo pipefail
-      echo "=== Disk usage BEFORE cleanup ==="
-      df -h /
-
-      # ── Remove large optional toolchains ──
-      sudo rm -rf ~/.cargo ~/.rustup ~/.dotnet /usr/share/swift \
-                   /opt/microsoft/msedge /usr/local/.ghcup /usr/lib/mono \
-                   /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-
-      # ── Snap packages (each is 200-500 MB) ──
-      sudo snap remove --purge lxd       2>/dev/null || true
-      sudo snap remove --purge core20    2>/dev/null || true
-      sudo snap remove --purge snapd     2>/dev/null || true
-      sudo apt-get purge -y snapd       2>/dev/null || true
-
-      echo "=== Disk usage AFTER cleanup ==="
-      df -h /
-    displayName: 'Reclaim disk space (Linux)'
+      bash "$(Build.SourcesDirectory)/build/scripts/host-cleanup-linux.sh"
+    displayName: Cleanup unused host dependencies
     condition: eq(variables['Agent.OS'], 'Linux')

--- a/build/scripts/host-cleanup-linux.sh
+++ b/build/scripts/host-cleanup-linux.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Reclaims disk space on Linux CI agents by removing pre-installed
+# software that is not needed for the build.
+#
+# This list is based on what the base image contains and
+# may need to be adjusted as new software gets installed.
+# Use the `du` command to determine what can be uninstalled.
+
+# Use sudo only when available (containers may not have it)
+if command -v sudo >/dev/null 2>&1; then
+  SUDO="sudo"
+else
+  SUDO=""
+fi
+
+echo "Disk space before cleanup:"
+df -h /
+
+rm -rf ~/.cargo ~/.rustup ~/.dotnet
+
+$SUDO rm -rf /usr/share/swift || true
+$SUDO rm -rf /opt/microsoft/msedge || true
+$SUDO rm -rf /usr/local/.ghcup || true
+$SUDO rm -rf /usr/lib/mono || true
+$SUDO rm -rf /usr/local/lib/android || true
+$SUDO rm -rf /opt/ghc || true
+$SUDO rm -rf /opt/hostedtoolcache/CodeQL || true
+
+$SUDO snap remove lxd || true
+$SUDO snap remove core20 || true
+$SUDO apt-get purge -y snapd || true
+
+echo "Disk space after cleanup:"
+df -h /

--- a/build/scripts/host-cleanup-linux.sh
+++ b/build/scripts/host-cleanup-linux.sh
@@ -6,9 +6,9 @@
 # may need to be adjusted as new software gets installed.
 # Use the `du` command to determine what can be uninstalled.
 
-# Use sudo only when available (containers may not have it)
-if command -v sudo >/dev/null 2>&1; then
-  SUDO="sudo"
+# Use sudo only when available and non-interactive (no password prompt)
+if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+  SUDO="sudo -n"
 else
   SUDO=""
 fi
@@ -16,7 +16,7 @@ fi
 echo "Disk space before cleanup:"
 df -h /
 
-rm -rf ~/.cargo ~/.rustup ~/.dotnet
+rm -rf ~/.cargo ~/.rustup ~/.dotnet || true
 
 $SUDO rm -rf /usr/share/swift || true
 $SUDO rm -rf /opt/microsoft/msedge || true
@@ -26,9 +26,14 @@ $SUDO rm -rf /usr/local/lib/android || true
 $SUDO rm -rf /opt/ghc || true
 $SUDO rm -rf /opt/hostedtoolcache/CodeQL || true
 
-$SUDO snap remove lxd || true
-$SUDO snap remove core20 || true
-$SUDO apt-get purge -y snapd || true
+if command -v snap >/dev/null 2>&1; then
+  timeout 60s $SUDO snap remove lxd || true
+  timeout 60s $SUDO snap remove core20 || true
+fi
+
+if command -v apt-get >/dev/null 2>&1; then
+  DEBIAN_FRONTEND=noninteractive timeout 120s $SUDO apt-get purge -y snapd || true
+fi
 
 echo "Disk space after cleanup:"
 df -h /


### PR DESCRIPTION
## What
Adds a Linux host disk cleanup step to all Linux CI jobs to reclaim disk space by removing unused pre-installed software.

## Why
Linux CI agents accumulate ~20–30 GB of pre-installed software (Cargo, Rust, Swift, Edge, GHC, Mono, Android SDK, CodeQL, snapd) that is not needed for builds. This cleanup step runs at the start of each Linux job to ensure sufficient disk space.

## Details
- Adds a shared shell script (`host-cleanup-linux.sh`) called by both the AzDO template and GHA composite action
- Cleanup is conditional on Linux (`condition: eq(variables['Agent.OS'], 'Linux')` / `if: runner.os == 'Linux'`)
- Uses `sudo -n` (non-interactive) probe to work safely in both host and container environments
- All removals are best-effort (`|| true`) with `timeout` guards on snap/apt-get commands
- Uses `DEBIAN_FRONTEND=noninteractive` for apt-get to prevent dpkg prompts

Part of org-wide CI disk cleanup initiative.
Related to https://github.com/unoplatform/uno.rider/pull/480