### PR TITLE
ci(canary): bump nuget.updater to 1.3.1

### DIFF
--- a/build/canary-updater.yml
+++ b/build/canary-updater.yml
@@ -9,7 +9,7 @@ steps:
       usePrivateFeed: false
       mergeBranch: true
       branchToMerge: master
-      nugetUpdaterVersion: '1.2.10'
+      nugetUpdaterVersion: '1.3.1'
       packageAuthor: 'unoplatform,uno platform'
       summaryFile: '$(Build.ArtifactStagingDirectory)/Canary.md'
       resultFile: '$(Build.ArtifactStagingDirectory)/result.json'


### PR DESCRIPTION
Bumps the canary `nuget.updater` to **1.3.1** for consistency with the rest of the canary fleet (Gallery / Themes / Rider / chefs / Toolkit / extensions / Studio / C# Markup all on 1.3.1) and to pick up the property-package fallback fix.

Single-source on the default branch; once merged, `canaries/dev` will be synced with `master`. No `UseDotNet` runtime pin here, so 1.3.1 (.NET 9) runs on the agent default.